### PR TITLE
Pin the NumPy ABI

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,7 @@ build:
 requirements:
   build:
     - python
-    - numpy
+    - numpy x.x
     - hdf5
     - cython
     - six
@@ -32,7 +32,7 @@ requirements:
 
   run:
     - python
-    - numpy
+    - numpy x.x
     - hdf5
     - six
     - unittest2    #[py26]


### PR DESCRIPTION
Fixes the NumPy ABI so that we are pinned against a particular version after linking to it.
