### PR TITLE
Bump build number (and update CI)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,12 @@ language: objective-c
 env:
   matrix:
     
-    - CONDA_PY=27  
-    - CONDA_PY=34  
-    - CONDA_PY=35  
+    - CONDA_NPY=110  CONDA_PY=27
+    - CONDA_NPY=19  CONDA_PY=27
+    - CONDA_NPY=110  CONDA_PY=34
+    - CONDA_NPY=19  CONDA_PY=34
+    - CONDA_NPY=110  CONDA_PY=35
+    - CONDA_NPY=19  CONDA_PY=35
   global:
     # The BINSTAR_TOKEN secure variable. This is defined canonically in conda-forge.yml.
     - secure: "q48hR6+qKPtY90GdtVp1vtn19NX9ogYcN9PHgsDGjgPRw0uvc7wvoaC/l9Kdqn3kXFclq0pQsX4k4F3nKANBdu6eVU4UImovkSAlp8Og9m0u1hQkPkhNnwV6INLlPWXxgUqCrQkfwtbCDbmytwjU0YeTZpEH5VdlTSROvYiuNCXD06AgNG/3AuP8ooO57Gabv110OHe1zJM5tUds7rIglLUSE9HyvjbtfZN+6H9px9+8E5NOA82+9Ps0ax46dD+frSgEh1Ka+GolB8qOOxgZR3eGdf6IkneV5WF6ax3PyXrJcoR+TlapDJchxX2BWnxG8Ae3YLY8Nk7hawfnJJ33I0akJOZCNBcIEcY2JoKJwTfXdzyj6sH2Lu39oO6/MRQ+RJuM2Tf4mxBZqz+kjH9ncDjJV0xiwZPDDKM0liQ+MbwgvtJFbc7k2Hmxxoc6ZjP9IqRBAkbFjdN9BroE0XP19wcCLQ55YAIxcRY+IvqWtYE5rtb2QJSEMDiZu5id+bmpf8yV/ZJ7C8yn3l6c+T+tnspJNCq5bAfTNv1gVc+yTKonX3GK1k+DVuNabPWiz/GPM+Q67FEKDd7e6j6Y0bcr9JHh4adXK0589ZilA5gs3ACEdQdiRBVE7C3ATNyC04oV1nh9BOR4eYJGXVA8lv6F3xS7/mmDHTIdBZx5ws6s9eo="

--- a/ci_support/run_docker_build.sh
+++ b/ci_support/run_docker_build.sh
@@ -43,9 +43,10 @@ conda info
 
 
 
-# Embarking on 3 case(s).
+# Embarking on 6 case(s).
 
     set -x
+    export CONDA_NPY=110
     export CONDA_PY=27
     set +x
     conda build /recipe_root --quiet || exit 1
@@ -55,6 +56,17 @@ conda info
     
 
     set -x
+    export CONDA_NPY=19
+    export CONDA_PY=27
+    set +x
+    conda build /recipe_root --quiet || exit 1
+    
+    /feedstock_root/ci_support/upload_or_check_non_existence.py /recipe_root conda-forge --channel=main || exit 1
+    
+    
+
+    set -x
+    export CONDA_NPY=110
     export CONDA_PY=34
     set +x
     conda build /recipe_root --quiet || exit 1
@@ -64,6 +76,27 @@ conda info
     
 
     set -x
+    export CONDA_NPY=19
+    export CONDA_PY=34
+    set +x
+    conda build /recipe_root --quiet || exit 1
+    
+    /feedstock_root/ci_support/upload_or_check_non_existence.py /recipe_root conda-forge --channel=main || exit 1
+    
+    
+
+    set -x
+    export CONDA_NPY=110
+    export CONDA_PY=35
+    set +x
+    conda build /recipe_root --quiet || exit 1
+    
+    /feedstock_root/ci_support/upload_or_check_non_existence.py /recipe_root conda-forge --channel=main || exit 1
+    
+    
+
+    set -x
+    export CONDA_NPY=19
     export CONDA_PY=35
     set +x
     conda build /recipe_root --quiet || exit 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,7 @@ source:
     - h5py_tests_old_test_file.py.patch
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win]
 
 requirements:


### PR DESCRIPTION
Tries to fix CI to adjust for the fact that NumPy ABI pinning happens now and prep for a new release.
