### PR TITLE
Add license_file metadata.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,7 @@ source:
     - h5py_win_setup_build.py.patch
 
 build:
-  number: 5
+  number: 6
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -44,6 +44,7 @@ test:
 about:
   home: http://www.h5py.org/
   license: BSD 3-Clause
+  license_file: licenses/license.txt
   summary: Read and write HDF5 files from Python.
 
 extra:


### PR DESCRIPTION
Add license_file metadata so that the license file is installed as part of the package.
