### PR TITLE
Remove explicit pinning of HDF5

### DIFF
--- a/.ci_support/linux_c_compilergccpython2.7.yaml
+++ b/.ci_support/linux_c_compilergccpython2.7.yaml
@@ -7,7 +7,7 @@ channel_sources:
 channel_targets:
 - conda-forge gcc7
 docker_image:
-- conda/c3i-linux-64
+- condaforge/linux-anvil-comp7
 numpy:
 - '1.9'
 pin_run_as_build:

--- a/.ci_support/linux_c_compilergccpython3.6.yaml
+++ b/.ci_support/linux_c_compilergccpython3.6.yaml
@@ -7,7 +7,7 @@ channel_sources:
 channel_targets:
 - conda-forge gcc7
 docker_image:
-- conda/c3i-linux-64
+- condaforge/linux-anvil-comp7
 numpy:
 - '1.9'
 pin_run_as_build:

--- a/.ci_support/linux_c_compilergccpython3.7.yaml
+++ b/.ci_support/linux_c_compilergccpython3.7.yaml
@@ -7,7 +7,7 @@ channel_sources:
 channel_targets:
 - conda-forge gcc7
 docker_image:
-- conda/c3i-linux-64
+- condaforge/linux-anvil-comp7
 numpy:
 - '1.9'
 pin_run_as_build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: eae41382be28b7264824450ce343dd625f972bedaaa3b0cced284986aabcbaee
 
 build:
-  number: 1003
+  number: 1004
 
 requirements:
   build:
@@ -18,14 +18,14 @@ requirements:
     - python
     - pip
     - numpy
-    - hdf5 1.10.2
+    - hdf5
     - cython
     - six
     - pkgconfig
   run:
     - python
     - {{ pin_compatible('numpy') }}
-    - hdf5 1.10.2
+    - hdf5
     - six
     - unittest2  # [py26 or py27]
     - pyreadline  # [win]


### PR DESCRIPTION
This merge adds a build of h5py with hdf5 1.10.3.

Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

closes #41 