### PR TITLE
Patch for hdf5 1.10.3

### DIFF
--- a/.ci_support/linux_c_compilergccpython2.7.yaml
+++ b/.ci_support/linux_c_compilergccpython2.7.yaml
@@ -7,10 +7,14 @@ channel_sources:
 channel_targets:
 - conda-forge gcc7
 docker_image:
-- conda/c3i-linux-64
+- condaforge/linux-anvil-comp7
+hdf5:
+- 1.10.3
 numpy:
 - '1.9'
 pin_run_as_build:
+  hdf5:
+    max_pin: x.x.x
   python:
     min_pin: x.x
     max_pin: x.x

--- a/.ci_support/linux_c_compilergccpython3.6.yaml
+++ b/.ci_support/linux_c_compilergccpython3.6.yaml
@@ -7,10 +7,14 @@ channel_sources:
 channel_targets:
 - conda-forge gcc7
 docker_image:
-- conda/c3i-linux-64
+- condaforge/linux-anvil-comp7
+hdf5:
+- 1.10.3
 numpy:
 - '1.9'
 pin_run_as_build:
+  hdf5:
+    max_pin: x.x.x
   python:
     min_pin: x.x
     max_pin: x.x

--- a/.ci_support/linux_c_compilergccpython3.7.yaml
+++ b/.ci_support/linux_c_compilergccpython3.7.yaml
@@ -7,10 +7,14 @@ channel_sources:
 channel_targets:
 - conda-forge gcc7
 docker_image:
-- conda/c3i-linux-64
+- condaforge/linux-anvil-comp7
+hdf5:
+- 1.10.3
 numpy:
 - '1.9'
 pin_run_as_build:
+  hdf5:
+    max_pin: x.x.x
   python:
     min_pin: x.x
     max_pin: x.x

--- a/.ci_support/linux_c_compilertoolchain_cpython2.7.yaml
+++ b/.ci_support/linux_c_compilertoolchain_cpython2.7.yaml
@@ -8,9 +8,13 @@ channel_targets:
 - conda-forge main
 docker_image:
 - condaforge/linux-anvil
+hdf5:
+- 1.10.3
 numpy:
 - '1.9'
 pin_run_as_build:
+  hdf5:
+    max_pin: x.x.x
   python:
     min_pin: x.x
     max_pin: x.x

--- a/.ci_support/linux_c_compilertoolchain_cpython3.6.yaml
+++ b/.ci_support/linux_c_compilertoolchain_cpython3.6.yaml
@@ -8,9 +8,13 @@ channel_targets:
 - conda-forge main
 docker_image:
 - condaforge/linux-anvil
+hdf5:
+- 1.10.3
 numpy:
 - '1.9'
 pin_run_as_build:
+  hdf5:
+    max_pin: x.x.x
   python:
     min_pin: x.x
     max_pin: x.x

--- a/.ci_support/linux_c_compilertoolchain_cpython3.7.yaml
+++ b/.ci_support/linux_c_compilertoolchain_cpython3.7.yaml
@@ -8,9 +8,13 @@ channel_targets:
 - conda-forge main
 docker_image:
 - condaforge/linux-anvil
+hdf5:
+- 1.10.3
 numpy:
 - '1.9'
 pin_run_as_build:
+  hdf5:
+    max_pin: x.x.x
   python:
     min_pin: x.x
     max_pin: x.x

--- a/.ci_support/osx_c_compilerclangpython2.7.yaml
+++ b/.ci_support/osx_c_compilerclangpython2.7.yaml
@@ -8,6 +8,8 @@ channel_sources:
 - conda-forge/label/gcc7,defaults
 channel_targets:
 - conda-forge gcc7
+hdf5:
+- 1.10.3
 macos_machine:
 - x86_64-apple-darwin13.4.0
 macos_min_version:
@@ -15,6 +17,8 @@ macos_min_version:
 numpy:
 - '1.9'
 pin_run_as_build:
+  hdf5:
+    max_pin: x.x.x
   python:
     min_pin: x.x
     max_pin: x.x

--- a/.ci_support/osx_c_compilerclangpython3.6.yaml
+++ b/.ci_support/osx_c_compilerclangpython3.6.yaml
@@ -8,6 +8,8 @@ channel_sources:
 - conda-forge/label/gcc7,defaults
 channel_targets:
 - conda-forge gcc7
+hdf5:
+- 1.10.3
 macos_machine:
 - x86_64-apple-darwin13.4.0
 macos_min_version:
@@ -15,6 +17,8 @@ macos_min_version:
 numpy:
 - '1.9'
 pin_run_as_build:
+  hdf5:
+    max_pin: x.x.x
   python:
     min_pin: x.x
     max_pin: x.x

--- a/.ci_support/osx_c_compilerclangpython3.7.yaml
+++ b/.ci_support/osx_c_compilerclangpython3.7.yaml
@@ -8,6 +8,8 @@ channel_sources:
 - conda-forge/label/gcc7,defaults
 channel_targets:
 - conda-forge gcc7
+hdf5:
+- 1.10.3
 macos_machine:
 - x86_64-apple-darwin13.4.0
 macos_min_version:
@@ -15,6 +17,8 @@ macos_min_version:
 numpy:
 - '1.9'
 pin_run_as_build:
+  hdf5:
+    max_pin: x.x.x
   python:
     min_pin: x.x
     max_pin: x.x

--- a/.ci_support/osx_c_compilertoolchain_cpython2.7.yaml
+++ b/.ci_support/osx_c_compilertoolchain_cpython2.7.yaml
@@ -8,6 +8,8 @@ channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
+hdf5:
+- 1.10.3
 macos_machine:
 - x86_64-apple-darwin13.4.0
 macos_min_version:
@@ -15,6 +17,8 @@ macos_min_version:
 numpy:
 - '1.9'
 pin_run_as_build:
+  hdf5:
+    max_pin: x.x.x
   python:
     min_pin: x.x
     max_pin: x.x

--- a/.ci_support/osx_c_compilertoolchain_cpython3.6.yaml
+++ b/.ci_support/osx_c_compilertoolchain_cpython3.6.yaml
@@ -8,6 +8,8 @@ channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
+hdf5:
+- 1.10.3
 macos_machine:
 - x86_64-apple-darwin13.4.0
 macos_min_version:
@@ -15,6 +17,8 @@ macos_min_version:
 numpy:
 - '1.9'
 pin_run_as_build:
+  hdf5:
+    max_pin: x.x.x
   python:
     min_pin: x.x
     max_pin: x.x

--- a/.ci_support/osx_c_compilertoolchain_cpython3.7.yaml
+++ b/.ci_support/osx_c_compilertoolchain_cpython3.7.yaml
@@ -8,6 +8,8 @@ channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
+hdf5:
+- 1.10.3
 macos_machine:
 - x86_64-apple-darwin13.4.0
 macos_min_version:
@@ -15,6 +17,8 @@ macos_min_version:
 numpy:
 - '1.9'
 pin_run_as_build:
+  hdf5:
+    max_pin: x.x.x
   python:
     min_pin: x.x
     max_pin: x.x

--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@ About h5py
 
 Home: http://www.h5py.org/
 
-Package license: BSD 3-Clause
+Package license: BSD-3-Clause
 
 Feedstock license: BSD 3-Clause
 
-Summary: Read and write HDF5 files from Python.
+Summary: Read and write HDF5 files from Python
 
 
 

--- a/recipe/backport_1099.patch
+++ b/recipe/backport_1099.patch
@@ -1,0 +1,16 @@
+--- h5py-2.8.0.orig/h5py/_errors.pyx	2018-05-13 21:33:33.000000000 -0300
++++ h5py-2.8.0/h5py/_errors.pyx	2018-10-22 14:50:56.674025360 -0300
+@@ -73,6 +73,13 @@
+     (H5E_SYM, H5E_CANTINIT):        ValueError, # Object already exists/1.8
+     (H5E_ARGS, H5E_BADTYPE):        ValueError, # Invalid location in file
+     (H5E_REFERENCE, H5E_CANTINIT):  ValueError, # Dereferencing invalid ref
++    
++    # needed for 1.10.3 to maintain compatibility with 1.10.{0,1,2}
++    
++    # due to changes to H5Gdeprec.c:H5Gget_num_objs
++    (H5E_SYM, H5E_BADTYPE):         ValueError, # Invalid location in file
++    # due to changes to H5F.c:H5Fstart_swmr_write
++    (H5E_FILE, H5E_CANTCONVERT):    ValueError, # Invalid file format
+   }
+ 
+ cdef struct err_data_t:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,9 +7,12 @@ package:
 source:
   url: https://github.com/h5py/h5py/archive/{{ version }}.tar.gz
   sha256: eae41382be28b7264824450ce343dd625f972bedaaa3b0cced284986aabcbaee
+  patches:
+    # drop when https://github.com/h5py/h5py/pull/1099 is merged.
+    - backport_1099.patch
 
 build:
-  number: 1003
+  number: 1004
 
 requirements:
   build:
@@ -18,14 +21,14 @@ requirements:
     - python
     - pip
     - numpy
-    - hdf5 1.10.2
+    - hdf5
     - cython
     - six
     - pkgconfig
   run:
     - python
     - {{ pin_compatible('numpy') }}
-    - hdf5 1.10.2
+    - hdf5
     - six
     - unittest2  # [py26 or py27]
     - pyreadline  # [win]
@@ -36,12 +39,13 @@ test:
 
 about:
   home: http://www.h5py.org/
-  license: BSD 3-Clause
+  license: BSD-3-Clause
   license_file: licenses/license.txt
-  summary: Read and write HDF5 files from Python.
+  summary: Read and write HDF5 files from Python
 
 extra:
   recipe-maintainers:
     - jakirkham
     - pitrou
     - tacaswell
+    - ocefpaf


### PR DESCRIPTION
We can drop this patch when it is merged upstream.