### PR TITLE
Bump build number

### DIFF
--- a/.ci_support/linux_c_compilergccpython2.7.yaml
+++ b/.ci_support/linux_c_compilergccpython2.7.yaml
@@ -9,12 +9,10 @@ channel_targets:
 docker_image:
 - condaforge/linux-anvil-comp7
 hdf5:
-- 1.10.3
+- 1.10.4
 numpy:
 - '1.9'
 pin_run_as_build:
-  hdf5:
-    max_pin: x.x.x
   python:
     min_pin: x.x
     max_pin: x.x

--- a/.ci_support/linux_c_compilergccpython3.6.yaml
+++ b/.ci_support/linux_c_compilergccpython3.6.yaml
@@ -9,12 +9,10 @@ channel_targets:
 docker_image:
 - condaforge/linux-anvil-comp7
 hdf5:
-- 1.10.3
+- 1.10.4
 numpy:
 - '1.9'
 pin_run_as_build:
-  hdf5:
-    max_pin: x.x.x
   python:
     min_pin: x.x
     max_pin: x.x

--- a/.ci_support/linux_c_compilergccpython3.7.yaml
+++ b/.ci_support/linux_c_compilergccpython3.7.yaml
@@ -9,12 +9,10 @@ channel_targets:
 docker_image:
 - condaforge/linux-anvil-comp7
 hdf5:
-- 1.10.3
+- 1.10.4
 numpy:
 - '1.9'
 pin_run_as_build:
-  hdf5:
-    max_pin: x.x.x
   python:
     min_pin: x.x
     max_pin: x.x

--- a/.ci_support/linux_c_compilertoolchain_cpython2.7.yaml
+++ b/.ci_support/linux_c_compilertoolchain_cpython2.7.yaml
@@ -9,12 +9,10 @@ channel_targets:
 docker_image:
 - condaforge/linux-anvil
 hdf5:
-- 1.10.3
+- 1.10.4
 numpy:
 - '1.9'
 pin_run_as_build:
-  hdf5:
-    max_pin: x.x.x
   python:
     min_pin: x.x
     max_pin: x.x

--- a/.ci_support/linux_c_compilertoolchain_cpython3.6.yaml
+++ b/.ci_support/linux_c_compilertoolchain_cpython3.6.yaml
@@ -9,12 +9,10 @@ channel_targets:
 docker_image:
 - condaforge/linux-anvil
 hdf5:
-- 1.10.3
+- 1.10.4
 numpy:
 - '1.9'
 pin_run_as_build:
-  hdf5:
-    max_pin: x.x.x
   python:
     min_pin: x.x
     max_pin: x.x

--- a/.ci_support/linux_c_compilertoolchain_cpython3.7.yaml
+++ b/.ci_support/linux_c_compilertoolchain_cpython3.7.yaml
@@ -9,12 +9,10 @@ channel_targets:
 docker_image:
 - condaforge/linux-anvil
 hdf5:
-- 1.10.3
+- 1.10.4
 numpy:
 - '1.9'
 pin_run_as_build:
-  hdf5:
-    max_pin: x.x.x
   python:
     min_pin: x.x
     max_pin: x.x

--- a/.ci_support/osx_c_compilerclangpython2.7.yaml
+++ b/.ci_support/osx_c_compilerclangpython2.7.yaml
@@ -9,7 +9,7 @@ channel_sources:
 channel_targets:
 - conda-forge gcc7
 hdf5:
-- 1.10.3
+- 1.10.4
 macos_machine:
 - x86_64-apple-darwin13.4.0
 macos_min_version:
@@ -17,8 +17,6 @@ macos_min_version:
 numpy:
 - '1.9'
 pin_run_as_build:
-  hdf5:
-    max_pin: x.x.x
   python:
     min_pin: x.x
     max_pin: x.x

--- a/.ci_support/osx_c_compilerclangpython3.6.yaml
+++ b/.ci_support/osx_c_compilerclangpython3.6.yaml
@@ -9,7 +9,7 @@ channel_sources:
 channel_targets:
 - conda-forge gcc7
 hdf5:
-- 1.10.3
+- 1.10.4
 macos_machine:
 - x86_64-apple-darwin13.4.0
 macos_min_version:
@@ -17,8 +17,6 @@ macos_min_version:
 numpy:
 - '1.9'
 pin_run_as_build:
-  hdf5:
-    max_pin: x.x.x
   python:
     min_pin: x.x
     max_pin: x.x

--- a/.ci_support/osx_c_compilerclangpython3.7.yaml
+++ b/.ci_support/osx_c_compilerclangpython3.7.yaml
@@ -9,7 +9,7 @@ channel_sources:
 channel_targets:
 - conda-forge gcc7
 hdf5:
-- 1.10.3
+- 1.10.4
 macos_machine:
 - x86_64-apple-darwin13.4.0
 macos_min_version:
@@ -17,8 +17,6 @@ macos_min_version:
 numpy:
 - '1.9'
 pin_run_as_build:
-  hdf5:
-    max_pin: x.x.x
   python:
     min_pin: x.x
     max_pin: x.x

--- a/.ci_support/osx_c_compilertoolchain_cpython2.7.yaml
+++ b/.ci_support/osx_c_compilertoolchain_cpython2.7.yaml
@@ -9,7 +9,7 @@ channel_sources:
 channel_targets:
 - conda-forge main
 hdf5:
-- 1.10.3
+- 1.10.4
 macos_machine:
 - x86_64-apple-darwin13.4.0
 macos_min_version:
@@ -17,8 +17,6 @@ macos_min_version:
 numpy:
 - '1.9'
 pin_run_as_build:
-  hdf5:
-    max_pin: x.x.x
   python:
     min_pin: x.x
     max_pin: x.x

--- a/.ci_support/osx_c_compilertoolchain_cpython3.6.yaml
+++ b/.ci_support/osx_c_compilertoolchain_cpython3.6.yaml
@@ -9,7 +9,7 @@ channel_sources:
 channel_targets:
 - conda-forge main
 hdf5:
-- 1.10.3
+- 1.10.4
 macos_machine:
 - x86_64-apple-darwin13.4.0
 macos_min_version:
@@ -17,8 +17,6 @@ macos_min_version:
 numpy:
 - '1.9'
 pin_run_as_build:
-  hdf5:
-    max_pin: x.x.x
   python:
     min_pin: x.x
     max_pin: x.x

--- a/.ci_support/osx_c_compilertoolchain_cpython3.7.yaml
+++ b/.ci_support/osx_c_compilertoolchain_cpython3.7.yaml
@@ -9,7 +9,7 @@ channel_sources:
 channel_targets:
 - conda-forge main
 hdf5:
-- 1.10.3
+- 1.10.4
 macos_machine:
 - x86_64-apple-darwin13.4.0
 macos_min_version:
@@ -17,8 +17,6 @@ macos_min_version:
 numpy:
 - '1.9'
 pin_run_as_build:
-  hdf5:
-    max_pin: x.x.x
   python:
     min_pin: x.x
     max_pin: x.x

--- a/.ci_support/win_c_compilervs2008python2.7.yaml
+++ b/.ci_support/win_c_compilervs2008python2.7.yaml
@@ -5,12 +5,10 @@ channel_sources:
 channel_targets:
 - conda-forge main
 hdf5:
-- 1.10.3
+- 1.10.4
 numpy:
 - '1.11'
 pin_run_as_build:
-  hdf5:
-    max_pin: x.x.x
   python:
     min_pin: x.x
     max_pin: x.x

--- a/.ci_support/win_c_compilervs2015python3.6.yaml
+++ b/.ci_support/win_c_compilervs2015python3.6.yaml
@@ -5,12 +5,10 @@ channel_sources:
 channel_targets:
 - conda-forge main
 hdf5:
-- 1.10.3
+- 1.10.4
 numpy:
 - '1.11'
 pin_run_as_build:
-  hdf5:
-    max_pin: x.x.x
   python:
     min_pin: x.x
     max_pin: x.x

--- a/.ci_support/win_c_compilervs2015python3.7.yaml
+++ b/.ci_support/win_c_compilervs2015python3.7.yaml
@@ -5,12 +5,10 @@ channel_sources:
 channel_targets:
 - conda-forge main
 hdf5:
-- 1.10.3
+- 1.10.4
 numpy:
 - '1.11'
 pin_run_as_build:
-  hdf5:
-    max_pin: x.x.x
   python:
     min_pin: x.x
     max_pin: x.x

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
     - backport_1099.patch
 
 build:
-  number: 1004
+  number: 1005
 
 requirements:
   build:


### PR DESCRIPTION
Need to pick up new version of HDF5 (1.10.4). This is related to https://github.com/conda-forge/gdal-feedstock/pull/243 where the new/fixed build of gdal can't be installed on Windows if you have h5py and netcdf4 installed since these packages are built for HDF5 1.10.3.

I've never had to deal with pinning with conda so let me know if it would be preferred to force the version to 1.10.4 or if this is good enough. If I've completely missed some change I need to make, obviously let me know.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
