### PR TITLE
Rebuild for hdf51106 (take 2)

### DIFF
--- a/.ci_support/linux_aarch64_mpimpichpython3.6.____cpython.yaml
+++ b/.ci_support/linux_aarch64_mpimpichpython3.6.____cpython.yaml
@@ -15,7 +15,7 @@ channel_targets:
 docker_image:
 - condaforge/linux-anvil-aarch64
 hdf5:
-- 1.10.5
+- 1.10.6
 mpi:
 - mpich
 numpy:

--- a/.ci_support/linux_aarch64_mpimpichpython3.7.____cpython.yaml
+++ b/.ci_support/linux_aarch64_mpimpichpython3.7.____cpython.yaml
@@ -15,7 +15,7 @@ channel_targets:
 docker_image:
 - condaforge/linux-anvil-aarch64
 hdf5:
-- 1.10.5
+- 1.10.6
 mpi:
 - mpich
 numpy:

--- a/.ci_support/linux_aarch64_mpimpichpython3.8.____cpython.yaml
+++ b/.ci_support/linux_aarch64_mpimpichpython3.8.____cpython.yaml
@@ -15,7 +15,7 @@ channel_targets:
 docker_image:
 - condaforge/linux-anvil-aarch64
 hdf5:
-- 1.10.5
+- 1.10.6
 mpi:
 - mpich
 numpy:

--- a/.ci_support/linux_aarch64_mpinompipython3.6.____cpython.yaml
+++ b/.ci_support/linux_aarch64_mpinompipython3.6.____cpython.yaml
@@ -15,7 +15,7 @@ channel_targets:
 docker_image:
 - condaforge/linux-anvil-aarch64
 hdf5:
-- 1.10.5
+- 1.10.6
 mpi:
 - nompi
 numpy:

--- a/.ci_support/linux_aarch64_mpinompipython3.7.____cpython.yaml
+++ b/.ci_support/linux_aarch64_mpinompipython3.7.____cpython.yaml
@@ -15,7 +15,7 @@ channel_targets:
 docker_image:
 - condaforge/linux-anvil-aarch64
 hdf5:
-- 1.10.5
+- 1.10.6
 mpi:
 - nompi
 numpy:

--- a/.ci_support/linux_aarch64_mpinompipython3.8.____cpython.yaml
+++ b/.ci_support/linux_aarch64_mpinompipython3.8.____cpython.yaml
@@ -15,7 +15,7 @@ channel_targets:
 docker_image:
 - condaforge/linux-anvil-aarch64
 hdf5:
-- 1.10.5
+- 1.10.6
 mpi:
 - nompi
 numpy:

--- a/.ci_support/linux_aarch64_mpiopenmpipython3.6.____cpython.yaml
+++ b/.ci_support/linux_aarch64_mpiopenmpipython3.6.____cpython.yaml
@@ -15,7 +15,7 @@ channel_targets:
 docker_image:
 - condaforge/linux-anvil-aarch64
 hdf5:
-- 1.10.5
+- 1.10.6
 mpi:
 - openmpi
 numpy:

--- a/.ci_support/linux_aarch64_mpiopenmpipython3.7.____cpython.yaml
+++ b/.ci_support/linux_aarch64_mpiopenmpipython3.7.____cpython.yaml
@@ -15,7 +15,7 @@ channel_targets:
 docker_image:
 - condaforge/linux-anvil-aarch64
 hdf5:
-- 1.10.5
+- 1.10.6
 mpi:
 - openmpi
 numpy:

--- a/.ci_support/linux_aarch64_mpiopenmpipython3.8.____cpython.yaml
+++ b/.ci_support/linux_aarch64_mpiopenmpipython3.8.____cpython.yaml
@@ -15,7 +15,7 @@ channel_targets:
 docker_image:
 - condaforge/linux-anvil-aarch64
 hdf5:
-- 1.10.5
+- 1.10.6
 mpi:
 - openmpi
 numpy:

--- a/.ci_support/linux_mpimpichpython3.6.____cpython.yaml
+++ b/.ci_support/linux_mpimpichpython3.6.____cpython.yaml
@@ -9,7 +9,7 @@ channel_targets:
 docker_image:
 - condaforge/linux-anvil-comp7
 hdf5:
-- 1.10.5
+- 1.10.6
 mpi:
 - mpich
 numpy:

--- a/.ci_support/linux_mpimpichpython3.7.____cpython.yaml
+++ b/.ci_support/linux_mpimpichpython3.7.____cpython.yaml
@@ -9,7 +9,7 @@ channel_targets:
 docker_image:
 - condaforge/linux-anvil-comp7
 hdf5:
-- 1.10.5
+- 1.10.6
 mpi:
 - mpich
 numpy:

--- a/.ci_support/linux_mpimpichpython3.8.____cpython.yaml
+++ b/.ci_support/linux_mpimpichpython3.8.____cpython.yaml
@@ -9,7 +9,7 @@ channel_targets:
 docker_image:
 - condaforge/linux-anvil-comp7
 hdf5:
-- 1.10.5
+- 1.10.6
 mpi:
 - mpich
 numpy:

--- a/.ci_support/linux_mpinompipython3.6.____cpython.yaml
+++ b/.ci_support/linux_mpinompipython3.6.____cpython.yaml
@@ -9,7 +9,7 @@ channel_targets:
 docker_image:
 - condaforge/linux-anvil-comp7
 hdf5:
-- 1.10.5
+- 1.10.6
 mpi:
 - nompi
 numpy:

--- a/.ci_support/linux_mpinompipython3.7.____cpython.yaml
+++ b/.ci_support/linux_mpinompipython3.7.____cpython.yaml
@@ -9,7 +9,7 @@ channel_targets:
 docker_image:
 - condaforge/linux-anvil-comp7
 hdf5:
-- 1.10.5
+- 1.10.6
 mpi:
 - nompi
 numpy:

--- a/.ci_support/linux_mpinompipython3.8.____cpython.yaml
+++ b/.ci_support/linux_mpinompipython3.8.____cpython.yaml
@@ -9,7 +9,7 @@ channel_targets:
 docker_image:
 - condaforge/linux-anvil-comp7
 hdf5:
-- 1.10.5
+- 1.10.6
 mpi:
 - nompi
 numpy:

--- a/.ci_support/linux_mpiopenmpipython3.6.____cpython.yaml
+++ b/.ci_support/linux_mpiopenmpipython3.6.____cpython.yaml
@@ -9,7 +9,7 @@ channel_targets:
 docker_image:
 - condaforge/linux-anvil-comp7
 hdf5:
-- 1.10.5
+- 1.10.6
 mpi:
 - openmpi
 numpy:

--- a/.ci_support/linux_mpiopenmpipython3.7.____cpython.yaml
+++ b/.ci_support/linux_mpiopenmpipython3.7.____cpython.yaml
@@ -9,7 +9,7 @@ channel_targets:
 docker_image:
 - condaforge/linux-anvil-comp7
 hdf5:
-- 1.10.5
+- 1.10.6
 mpi:
 - openmpi
 numpy:

--- a/.ci_support/linux_mpiopenmpipython3.8.____cpython.yaml
+++ b/.ci_support/linux_mpiopenmpipython3.8.____cpython.yaml
@@ -9,7 +9,7 @@ channel_targets:
 docker_image:
 - condaforge/linux-anvil-comp7
 hdf5:
-- 1.10.5
+- 1.10.6
 mpi:
 - openmpi
 numpy:

--- a/.ci_support/linux_ppc64le_mpimpichpython3.6.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_mpimpichpython3.6.____cpython.yaml
@@ -9,7 +9,7 @@ channel_targets:
 docker_image:
 - condaforge/linux-anvil-ppc64le
 hdf5:
-- 1.10.5
+- 1.10.6
 mpi:
 - mpich
 numpy:

--- a/.ci_support/linux_ppc64le_mpimpichpython3.7.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_mpimpichpython3.7.____cpython.yaml
@@ -9,7 +9,7 @@ channel_targets:
 docker_image:
 - condaforge/linux-anvil-ppc64le
 hdf5:
-- 1.10.5
+- 1.10.6
 mpi:
 - mpich
 numpy:

--- a/.ci_support/linux_ppc64le_mpimpichpython3.8.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_mpimpichpython3.8.____cpython.yaml
@@ -9,7 +9,7 @@ channel_targets:
 docker_image:
 - condaforge/linux-anvil-ppc64le
 hdf5:
-- 1.10.5
+- 1.10.6
 mpi:
 - mpich
 numpy:

--- a/.ci_support/linux_ppc64le_mpinompipython3.6.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_mpinompipython3.6.____cpython.yaml
@@ -9,7 +9,7 @@ channel_targets:
 docker_image:
 - condaforge/linux-anvil-ppc64le
 hdf5:
-- 1.10.5
+- 1.10.6
 mpi:
 - nompi
 numpy:

--- a/.ci_support/linux_ppc64le_mpinompipython3.7.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_mpinompipython3.7.____cpython.yaml
@@ -9,7 +9,7 @@ channel_targets:
 docker_image:
 - condaforge/linux-anvil-ppc64le
 hdf5:
-- 1.10.5
+- 1.10.6
 mpi:
 - nompi
 numpy:

--- a/.ci_support/linux_ppc64le_mpinompipython3.8.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_mpinompipython3.8.____cpython.yaml
@@ -9,7 +9,7 @@ channel_targets:
 docker_image:
 - condaforge/linux-anvil-ppc64le
 hdf5:
-- 1.10.5
+- 1.10.6
 mpi:
 - nompi
 numpy:

--- a/.ci_support/linux_ppc64le_mpiopenmpipython3.6.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_mpiopenmpipython3.6.____cpython.yaml
@@ -9,7 +9,7 @@ channel_targets:
 docker_image:
 - condaforge/linux-anvil-ppc64le
 hdf5:
-- 1.10.5
+- 1.10.6
 mpi:
 - openmpi
 numpy:

--- a/.ci_support/linux_ppc64le_mpiopenmpipython3.7.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_mpiopenmpipython3.7.____cpython.yaml
@@ -9,7 +9,7 @@ channel_targets:
 docker_image:
 - condaforge/linux-anvil-ppc64le
 hdf5:
-- 1.10.5
+- 1.10.6
 mpi:
 - openmpi
 numpy:

--- a/.ci_support/linux_ppc64le_mpiopenmpipython3.8.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_mpiopenmpipython3.8.____cpython.yaml
@@ -9,7 +9,7 @@ channel_targets:
 docker_image:
 - condaforge/linux-anvil-ppc64le
 hdf5:
-- 1.10.5
+- 1.10.6
 mpi:
 - openmpi
 numpy:

--- a/.ci_support/migrations/hdf51106.yaml
+++ b/.ci_support/migrations/hdf51106.yaml
@@ -1,0 +1,7 @@
+__migrator:
+  build_number: 1
+  kind: version
+  migration_number: 1
+hdf5:
+- 1.10.6
+migrator_ts: 1587001869.689825

--- a/.ci_support/osx_mpimpichpython3.6.____cpython.yaml
+++ b/.ci_support/osx_mpimpichpython3.6.____cpython.yaml
@@ -9,7 +9,7 @@ channel_sources:
 channel_targets:
 - conda-forge main
 hdf5:
-- 1.10.5
+- 1.10.6
 macos_machine:
 - x86_64-apple-darwin13.4.0
 macos_min_version:

--- a/.ci_support/osx_mpimpichpython3.7.____cpython.yaml
+++ b/.ci_support/osx_mpimpichpython3.7.____cpython.yaml
@@ -9,7 +9,7 @@ channel_sources:
 channel_targets:
 - conda-forge main
 hdf5:
-- 1.10.5
+- 1.10.6
 macos_machine:
 - x86_64-apple-darwin13.4.0
 macos_min_version:

--- a/.ci_support/osx_mpimpichpython3.8.____cpython.yaml
+++ b/.ci_support/osx_mpimpichpython3.8.____cpython.yaml
@@ -9,7 +9,7 @@ channel_sources:
 channel_targets:
 - conda-forge main
 hdf5:
-- 1.10.5
+- 1.10.6
 macos_machine:
 - x86_64-apple-darwin13.4.0
 macos_min_version:

--- a/.ci_support/osx_mpinompipython3.6.____cpython.yaml
+++ b/.ci_support/osx_mpinompipython3.6.____cpython.yaml
@@ -9,7 +9,7 @@ channel_sources:
 channel_targets:
 - conda-forge main
 hdf5:
-- 1.10.5
+- 1.10.6
 macos_machine:
 - x86_64-apple-darwin13.4.0
 macos_min_version:

--- a/.ci_support/osx_mpinompipython3.7.____cpython.yaml
+++ b/.ci_support/osx_mpinompipython3.7.____cpython.yaml
@@ -9,7 +9,7 @@ channel_sources:
 channel_targets:
 - conda-forge main
 hdf5:
-- 1.10.5
+- 1.10.6
 macos_machine:
 - x86_64-apple-darwin13.4.0
 macos_min_version:

--- a/.ci_support/osx_mpinompipython3.8.____cpython.yaml
+++ b/.ci_support/osx_mpinompipython3.8.____cpython.yaml
@@ -9,7 +9,7 @@ channel_sources:
 channel_targets:
 - conda-forge main
 hdf5:
-- 1.10.5
+- 1.10.6
 macos_machine:
 - x86_64-apple-darwin13.4.0
 macos_min_version:

--- a/.ci_support/osx_mpiopenmpipython3.6.____cpython.yaml
+++ b/.ci_support/osx_mpiopenmpipython3.6.____cpython.yaml
@@ -9,7 +9,7 @@ channel_sources:
 channel_targets:
 - conda-forge main
 hdf5:
-- 1.10.5
+- 1.10.6
 macos_machine:
 - x86_64-apple-darwin13.4.0
 macos_min_version:

--- a/.ci_support/osx_mpiopenmpipython3.7.____cpython.yaml
+++ b/.ci_support/osx_mpiopenmpipython3.7.____cpython.yaml
@@ -9,7 +9,7 @@ channel_sources:
 channel_targets:
 - conda-forge main
 hdf5:
-- 1.10.5
+- 1.10.6
 macos_machine:
 - x86_64-apple-darwin13.4.0
 macos_min_version:

--- a/.ci_support/osx_mpiopenmpipython3.8.____cpython.yaml
+++ b/.ci_support/osx_mpiopenmpipython3.8.____cpython.yaml
@@ -9,7 +9,7 @@ channel_sources:
 channel_targets:
 - conda-forge main
 hdf5:
-- 1.10.5
+- 1.10.6
 macos_machine:
 - x86_64-apple-darwin13.4.0
 macos_min_version:

--- a/.ci_support/win_python3.6.____cpython.yaml
+++ b/.ci_support/win_python3.6.____cpython.yaml
@@ -5,7 +5,7 @@ channel_sources:
 channel_targets:
 - conda-forge main
 hdf5:
-- 1.10.5
+- 1.10.6
 mpi:
 - nompi
 numpy:

--- a/.ci_support/win_python3.7.____cpython.yaml
+++ b/.ci_support/win_python3.7.____cpython.yaml
@@ -5,7 +5,7 @@ channel_sources:
 channel_targets:
 - conda-forge main
 hdf5:
-- 1.10.5
+- 1.10.6
 mpi:
 - nompi
 numpy:

--- a/.ci_support/win_python3.8.____cpython.yaml
+++ b/.ci_support/win_python3.8.____cpython.yaml
@@ -5,7 +5,7 @@ channel_sources:
 channel_targets:
 - conda-forge main
 hdf5:
-- 1.10.5
+- 1.10.6
 mpi:
 - nompi
 numpy:

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,8 +1,5 @@
 appveyor:
   secure: {BINSTAR_TOKEN: tumuXLL8PU75WMnRDemRy02ruEq2RpNxeK3dz0MjFssnosPm2v4EFjfNB4PTotA1}
-compiler_stack: comp7
-max_py_ver: '37'
-max_r_ver: '35'
 provider: {linux_aarch64: default, linux_ppc64le: default, win: azure}
 travis:
   secure: {BINSTAR_TOKEN: WQBwSPsgMAHlQeNe4e9VCSFHqGUh3nTRAx8E3CVtTA9imNoUjIIG/UXE9WIfJ6GNVYT6uWfte7CXE5AGLWBExu/cTHm1FqkXoannwf6vhcdjq2+cCb59h+KRZanWTXV67Mbglt+ajdWtisoHtJpwcgFGLSEDee2IJ5T8di8cCIghlGb3QNsQJPaEdUx//N/YiKNf+4viewT4F2+/2TAX0tt2MvjEO+5Jz05dS+93VqtuEo/GEhMyEphKBok8xFXxImJjSQ2m+j6innAGke4eWNpc+iik6dAmESnXXU45ecLC4kPMQNPdWFIFoi3Jcy8/xXvj/krVk4VsFc+s8vGMvcY2cwKY9qO1V/feYUxaor4C6o57NTm8yc8ZBCf7MUONDrxOFesl6RmdjVIyZOo5t3pSfNntxN3GbagTmVVnJlXC7TUhNehyqUXtJ3Ww4qxJDtUNhH0dvAID60sTttjCHDctyeJmeWn+wAvOp9CEvXcReZ+AZ2/irOCqsXDQDyEalY9xK2dgj/5xvVYfIgT/P+Zk77UZrWVY/0ZTdSUPv6GeJvDq1Q2ZEyCFf2pxUX/4ZmBFwSc5GFlZItgkyXZlTI9r/+W7HKB7gc0nZ9/wdv3zseEwjiZvI6Fqr/FONgtwTicOQOfFxNYu4vO7cg5mDMjrWNrOI2JKG0lTviNGOy4=}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,6 +22,8 @@ source:
     # see https://github.com/h5py/h5py/issues/1244
     #     https://github.com/h5py/h5py/pull/1325
     - ppc64le_test.patch
+    # skip failing unicode test on windows
+    - skip-failing-unicode-test.patch  # [win]
 
 build:
   number: {{ build }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set version = "2.10.0" %}
-{% set build = 2 %}
+{% set build = 3 %}
 
 # mpi must be defined for conda-smithy lint
 {% set mpi = mpi or 'nompi' %}

--- a/recipe/skip-failing-unicode-test.patch
+++ b/recipe/skip-failing-unicode-test.patch
@@ -1,0 +1,12 @@
+diff --git a/h5py/tests/__init__.py b/h5py/tests/__init__.py
+index 3fb68a2d..bb525b97 100644
+--- a/h5py/tests/__init__.py
++++ b/h5py/tests/__init__.py
+@@ -18,6 +18,6 @@ def run_tests(args=''):
+         from shlex import split
+         from subprocess import call
+         from sys import executable
+-        cli = [executable, "-m", "pytest", "--pyargs", "h5py"]
++        cli = [executable, "-m", "pytest", "--pyargs", "h5py", "-k", "not test_unicode_hdf5_python_consistent"]
+         cli.extend(split(args))
+         return call(cli)


### PR DESCRIPTION
This PR closes #75 by adding an extra patch to disable a failing unicode test on windows.

I went with my [original patch](https://github.com/conda-forge/h5py-feedstock/pull/75#issuecomment-650083339) rather than modifying `run_tests.py` as I think the patch will be more easily remembered as something to remove in the future, whenever the upstream problem is actually resolved; it's also easier to apply only on a single platform.

Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
