### PR TITLE
Remove dependency on dead pyreadline on Windows

### DIFF
--- a/.ci_support/osx_arm64_mpimpichpython3.8.____cpython.yaml
+++ b/.ci_support/osx_arm64_mpimpichpython3.8.____cpython.yaml
@@ -5,7 +5,7 @@ c_compiler:
 c_compiler_version:
 - '11'
 channel_sources:
-- conda-forge/label/rust_dev,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 hdf5:

--- a/.ci_support/osx_arm64_mpimpichpython3.9.____cpython.yaml
+++ b/.ci_support/osx_arm64_mpimpichpython3.9.____cpython.yaml
@@ -5,7 +5,7 @@ c_compiler:
 c_compiler_version:
 - '11'
 channel_sources:
-- conda-forge/label/rust_dev,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 hdf5:

--- a/.ci_support/osx_arm64_mpinompipython3.8.____cpython.yaml
+++ b/.ci_support/osx_arm64_mpinompipython3.8.____cpython.yaml
@@ -5,7 +5,7 @@ c_compiler:
 c_compiler_version:
 - '11'
 channel_sources:
-- conda-forge/label/rust_dev,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 hdf5:

--- a/.ci_support/osx_arm64_mpinompipython3.9.____cpython.yaml
+++ b/.ci_support/osx_arm64_mpinompipython3.9.____cpython.yaml
@@ -5,7 +5,7 @@ c_compiler:
 c_compiler_version:
 - '11'
 channel_sources:
-- conda-forge/label/rust_dev,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 hdf5:

--- a/.ci_support/osx_arm64_mpiopenmpipython3.8.____cpython.yaml
+++ b/.ci_support/osx_arm64_mpiopenmpipython3.8.____cpython.yaml
@@ -5,7 +5,7 @@ c_compiler:
 c_compiler_version:
 - '11'
 channel_sources:
-- conda-forge/label/rust_dev,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 hdf5:

--- a/.ci_support/osx_arm64_mpiopenmpipython3.9.____cpython.yaml
+++ b/.ci_support/osx_arm64_mpiopenmpipython3.9.____cpython.yaml
@@ -5,7 +5,7 @@ c_compiler:
 c_compiler_version:
 - '11'
 channel_sources:
-- conda-forge/label/rust_dev,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 hdf5:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -70,7 +70,6 @@ requirements:
     - mpi4py >=3.0  # [mpi != 'nompi']
     # hdf5 >=1.10.4 has run_exports
     - hdf5
-    - pyreadline  # [win]
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set version = "3.4.0" %}
-{% set build = 0 %}
+{% set build = 1 %}
 
 # mpi must be defined for conda-smithy lint
 {% set mpi = mpi or 'nompi' %}


### PR DESCRIPTION
Remove dependency on `pyreadline` on windows. 

` pyreadline` is a dead library on windows and triggers deprecation warnings. This dependency on pyreadline will also cause [h5py to stop working on python 3.10](https://github.com/pyreadline/pyreadline/issues/65).

The dependency is only used for an [interactive support function](https://github.com/h5py/h5py/blob/cff8537cc74a4897e2c0dc523309be17bec06dd4/h5py/__init__.py#L98) to enable readline ipython completions in interactive sesssions. Since the newest version of ipython doesn't use readline anyway on windows this dependency can be safely removed. 

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
