### PR TITLE
Don't install cached-property on python 3.8+

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -61,7 +61,7 @@ requirements:
     - pkgconfig
   run:
     - python
-    - cached-property
+    - cached-property  # [py<38]    
     - {{ pin_compatible('numpy') }}
     - {{ mpi }}  # [mpi != 'nompi']
     - mpi4py >=3.0  # [mpi != 'nompi']

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set version = "3.6.0" %}
-{% set build = 0 %}
+{% set build = 1 %}
 
 # mpi must be defined for conda-smithy lint
 {% set mpi = mpi or 'nompi' %}


### PR DESCRIPTION
cached_property is available in the stdlib for python 3.8+
