### PR TITLE
Rebuild for 3.14t and fix linter issue.

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -28,6 +28,10 @@ jobs:
         CONFIG: linux_64_mpimpichpython3.14.____cp314
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+      linux_64_mpimpichpython3.14.____cp314t:
+        CONFIG: linux_64_mpimpichpython3.14.____cp314t
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
       linux_64_mpinompipython3.10.____cpython:
         CONFIG: linux_64_mpinompipython3.10.____cpython
         UPLOAD_PACKAGES: 'True'
@@ -46,6 +50,10 @@ jobs:
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
       linux_64_mpinompipython3.14.____cp314:
         CONFIG: linux_64_mpinompipython3.14.____cp314
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+      linux_64_mpinompipython3.14.____cp314t:
+        CONFIG: linux_64_mpinompipython3.14.____cp314t
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
       linux_64_mpiopenmpipython3.10.____cpython:
@@ -68,6 +76,10 @@ jobs:
         CONFIG: linux_64_mpiopenmpipython3.14.____cp314
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+      linux_64_mpiopenmpipython3.14.____cp314t:
+        CONFIG: linux_64_mpiopenmpipython3.14.____cp314t
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
       linux_aarch64_mpimpichpython3.10.____cpython:
         CONFIG: linux_aarch64_mpimpichpython3.10.____cpython
         UPLOAD_PACKAGES: 'True'
@@ -86,6 +98,10 @@ jobs:
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
       linux_aarch64_mpimpichpython3.14.____cp314:
         CONFIG: linux_aarch64_mpimpichpython3.14.____cp314
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+      linux_aarch64_mpimpichpython3.14.____cp314t:
+        CONFIG: linux_aarch64_mpimpichpython3.14.____cp314t
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
       linux_aarch64_mpinompipython3.10.____cpython:
@@ -108,6 +124,10 @@ jobs:
         CONFIG: linux_aarch64_mpinompipython3.14.____cp314
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+      linux_aarch64_mpinompipython3.14.____cp314t:
+        CONFIG: linux_aarch64_mpinompipython3.14.____cp314t
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
       linux_aarch64_mpiopenmpipython3.10.____cpython:
         CONFIG: linux_aarch64_mpiopenmpipython3.10.____cpython
         UPLOAD_PACKAGES: 'True'
@@ -126,6 +146,10 @@ jobs:
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
       linux_aarch64_mpiopenmpipython3.14.____cp314:
         CONFIG: linux_aarch64_mpiopenmpipython3.14.____cp314
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+      linux_aarch64_mpiopenmpipython3.14.____cp314t:
+        CONFIG: linux_aarch64_mpiopenmpipython3.14.____cp314t
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
       linux_ppc64le_mpimpichpython3.10.____cpython:
@@ -148,6 +172,10 @@ jobs:
         CONFIG: linux_ppc64le_mpimpichpython3.14.____cp314
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+      linux_ppc64le_mpimpichpython3.14.____cp314t:
+        CONFIG: linux_ppc64le_mpimpichpython3.14.____cp314t
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
       linux_ppc64le_mpinompipython3.10.____cpython:
         CONFIG: linux_ppc64le_mpinompipython3.10.____cpython
         UPLOAD_PACKAGES: 'True'
@@ -168,6 +196,10 @@ jobs:
         CONFIG: linux_ppc64le_mpinompipython3.14.____cp314
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+      linux_ppc64le_mpinompipython3.14.____cp314t:
+        CONFIG: linux_ppc64le_mpinompipython3.14.____cp314t
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
       linux_ppc64le_mpiopenmpipython3.10.____cpython:
         CONFIG: linux_ppc64le_mpiopenmpipython3.10.____cpython
         UPLOAD_PACKAGES: 'True'
@@ -186,6 +218,10 @@ jobs:
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
       linux_ppc64le_mpiopenmpipython3.14.____cp314:
         CONFIG: linux_ppc64le_mpiopenmpipython3.14.____cp314
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+      linux_ppc64le_mpiopenmpipython3.14.____cp314t:
+        CONFIG: linux_ppc64le_mpiopenmpipython3.14.____cp314t
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
     maxParallel: 28

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -23,6 +23,9 @@ jobs:
       osx_64_mpimpichpython3.14.____cp314:
         CONFIG: osx_64_mpimpichpython3.14.____cp314
         UPLOAD_PACKAGES: 'True'
+      osx_64_mpimpichpython3.14.____cp314t:
+        CONFIG: osx_64_mpimpichpython3.14.____cp314t
+        UPLOAD_PACKAGES: 'True'
       osx_64_mpinompipython3.10.____cpython:
         CONFIG: osx_64_mpinompipython3.10.____cpython
         UPLOAD_PACKAGES: 'True'
@@ -37,6 +40,9 @@ jobs:
         UPLOAD_PACKAGES: 'True'
       osx_64_mpinompipython3.14.____cp314:
         CONFIG: osx_64_mpinompipython3.14.____cp314
+        UPLOAD_PACKAGES: 'True'
+      osx_64_mpinompipython3.14.____cp314t:
+        CONFIG: osx_64_mpinompipython3.14.____cp314t
         UPLOAD_PACKAGES: 'True'
       osx_64_mpiopenmpipython3.10.____cpython:
         CONFIG: osx_64_mpiopenmpipython3.10.____cpython
@@ -53,6 +59,9 @@ jobs:
       osx_64_mpiopenmpipython3.14.____cp314:
         CONFIG: osx_64_mpiopenmpipython3.14.____cp314
         UPLOAD_PACKAGES: 'True'
+      osx_64_mpiopenmpipython3.14.____cp314t:
+        CONFIG: osx_64_mpiopenmpipython3.14.____cp314t
+        UPLOAD_PACKAGES: 'True'
       osx_arm64_mpimpichpython3.10.____cpython:
         CONFIG: osx_arm64_mpimpichpython3.10.____cpython
         UPLOAD_PACKAGES: 'True'
@@ -67,6 +76,9 @@ jobs:
         UPLOAD_PACKAGES: 'True'
       osx_arm64_mpimpichpython3.14.____cp314:
         CONFIG: osx_arm64_mpimpichpython3.14.____cp314
+        UPLOAD_PACKAGES: 'True'
+      osx_arm64_mpimpichpython3.14.____cp314t:
+        CONFIG: osx_arm64_mpimpichpython3.14.____cp314t
         UPLOAD_PACKAGES: 'True'
       osx_arm64_mpinompipython3.10.____cpython:
         CONFIG: osx_arm64_mpinompipython3.10.____cpython
@@ -83,6 +95,9 @@ jobs:
       osx_arm64_mpinompipython3.14.____cp314:
         CONFIG: osx_arm64_mpinompipython3.14.____cp314
         UPLOAD_PACKAGES: 'True'
+      osx_arm64_mpinompipython3.14.____cp314t:
+        CONFIG: osx_arm64_mpinompipython3.14.____cp314t
+        UPLOAD_PACKAGES: 'True'
       osx_arm64_mpiopenmpipython3.10.____cpython:
         CONFIG: osx_arm64_mpiopenmpipython3.10.____cpython
         UPLOAD_PACKAGES: 'True'
@@ -97,6 +112,9 @@ jobs:
         UPLOAD_PACKAGES: 'True'
       osx_arm64_mpiopenmpipython3.14.____cp314:
         CONFIG: osx_arm64_mpiopenmpipython3.14.____cp314
+        UPLOAD_PACKAGES: 'True'
+      osx_arm64_mpiopenmpipython3.14.____cp314t:
+        CONFIG: osx_arm64_mpiopenmpipython3.14.____cp314t
         UPLOAD_PACKAGES: 'True'
     maxParallel: 19
   timeoutInMinutes: 360

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -23,6 +23,9 @@ jobs:
       win_64_python3.14.____cp314:
         CONFIG: win_64_python3.14.____cp314
         UPLOAD_PACKAGES: 'True'
+      win_64_python3.14.____cp314t:
+        CONFIG: win_64_python3.14.____cp314t
+        UPLOAD_PACKAGES: 'True'
     maxParallel: 3
   timeoutInMinutes: 360
   variables:

--- a/.ci_support/linux_64_mpimpichpython3.14.____cp314t.yaml
+++ b/.ci_support/linux_64_mpimpichpython3.14.____cp314t.yaml
@@ -1,0 +1,32 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '14'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
+hdf5:
+- 1.14.6
+mpi:
+- mpich
+mpich:
+- '4'
+numpy:
+- '2'
+openmpi:
+- '5'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.14.* *_cp314t
+target_platform:
+- linux-64

--- a/.ci_support/linux_64_mpinompipython3.14.____cp314t.yaml
+++ b/.ci_support/linux_64_mpinompipython3.14.____cp314t.yaml
@@ -1,0 +1,32 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '14'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
+hdf5:
+- 1.14.6
+mpi:
+- nompi
+mpich:
+- '4'
+numpy:
+- '2'
+openmpi:
+- '5'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.14.* *_cp314t
+target_platform:
+- linux-64

--- a/.ci_support/linux_64_mpiopenmpipython3.14.____cp314t.yaml
+++ b/.ci_support/linux_64_mpiopenmpipython3.14.____cp314t.yaml
@@ -1,0 +1,32 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '14'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
+hdf5:
+- 1.14.6
+mpi:
+- openmpi
+mpich:
+- '4'
+numpy:
+- '2'
+openmpi:
+- '5'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.14.* *_cp314t
+target_platform:
+- linux-64

--- a/.ci_support/linux_aarch64_mpimpichpython3.14.____cp314t.yaml
+++ b/.ci_support/linux_aarch64_mpimpichpython3.14.____cp314t.yaml
@@ -1,0 +1,32 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '14'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
+hdf5:
+- 1.14.6
+mpi:
+- mpich
+mpich:
+- '4'
+numpy:
+- '2'
+openmpi:
+- '5'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.14.* *_cp314t
+target_platform:
+- linux-aarch64

--- a/.ci_support/linux_aarch64_mpinompipython3.14.____cp314t.yaml
+++ b/.ci_support/linux_aarch64_mpinompipython3.14.____cp314t.yaml
@@ -1,0 +1,32 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '14'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
+hdf5:
+- 1.14.6
+mpi:
+- nompi
+mpich:
+- '4'
+numpy:
+- '2'
+openmpi:
+- '5'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.14.* *_cp314t
+target_platform:
+- linux-aarch64

--- a/.ci_support/linux_aarch64_mpiopenmpipython3.14.____cp314t.yaml
+++ b/.ci_support/linux_aarch64_mpiopenmpipython3.14.____cp314t.yaml
@@ -1,0 +1,32 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '14'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
+hdf5:
+- 1.14.6
+mpi:
+- openmpi
+mpich:
+- '4'
+numpy:
+- '2'
+openmpi:
+- '5'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.14.* *_cp314t
+target_platform:
+- linux-aarch64

--- a/.ci_support/linux_ppc64le_mpimpichpython3.14.____cp314t.yaml
+++ b/.ci_support/linux_ppc64le_mpimpichpython3.14.____cp314t.yaml
@@ -1,0 +1,32 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '14'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
+hdf5:
+- 1.14.6
+mpi:
+- mpich
+mpich:
+- '4'
+numpy:
+- '2'
+openmpi:
+- '5'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.14.* *_cp314t
+target_platform:
+- linux-ppc64le

--- a/.ci_support/linux_ppc64le_mpinompipython3.14.____cp314t.yaml
+++ b/.ci_support/linux_ppc64le_mpinompipython3.14.____cp314t.yaml
@@ -1,0 +1,32 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '14'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
+hdf5:
+- 1.14.6
+mpi:
+- nompi
+mpich:
+- '4'
+numpy:
+- '2'
+openmpi:
+- '5'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.14.* *_cp314t
+target_platform:
+- linux-ppc64le

--- a/.ci_support/linux_ppc64le_mpiopenmpipython3.14.____cp314t.yaml
+++ b/.ci_support/linux_ppc64le_mpiopenmpipython3.14.____cp314t.yaml
@@ -1,0 +1,32 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '14'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
+hdf5:
+- 1.14.6
+mpi:
+- openmpi
+mpich:
+- '4'
+numpy:
+- '2'
+openmpi:
+- '5'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.14.* *_cp314t
+target_platform:
+- linux-ppc64le

--- a/.ci_support/migrations/python314t.yaml
+++ b/.ci_support/migrations/python314t.yaml
@@ -1,0 +1,49 @@
+migrator_ts: 1755739493
+__migrator:
+    commit_message: Rebuild for python 3.14 freethreading
+    migration_number: 1
+    operation: key_add
+    primary_key: python
+    ordering:
+        python:
+            - 3.9.* *_cpython
+            - 3.10.* *_cpython
+            - 3.11.* *_cpython
+            - 3.12.* *_cpython
+            - 3.13.* *_cp313
+            - 3.13.* *_cp313t
+            - 3.14.* *_cp314    # new entry
+            - 3.14.* *_cp314t   # new entry
+    longterm: true
+    pr_limit: 20
+    max_solver_attempts: 3  # this will make the bot retry "not solvable" stuff 12 times
+    exclude:
+        # this shouldn't attempt to modify the python feedstocks
+        - python
+        - pypy3.6
+        - pypy-meta
+        - cross-python
+        - python_abi
+    exclude_pinned_pkgs: false
+    # if feedstock already has 3.13t migrator this is redundant, but harmless
+    additional_zip_keys:
+        - is_freethreading
+        - is_abi3
+    wait_for_migrators:
+        - python314
+    ignored_deps_per_node:
+        matplotlib:
+            - pyqt
+    allowlist_file: free-threaded-314.txt
+
+python:
+- 3.14.* *_cp314t
+# additional entries to add for zip_keys
+is_freethreading:
+- true
+is_python_min:
+- false
+is_abi3:
+- false
+# channel_sources:
+# - conda-forge

--- a/.ci_support/osx_64_mpimpichpython3.14.____cp314t.yaml
+++ b/.ci_support/osx_64_mpimpichpython3.14.____cp314t.yaml
@@ -1,0 +1,36 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.13'
+MACOSX_SDK_VERSION:
+- '10.13'
+c_compiler:
+- clang
+c_compiler_version:
+- '19'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '10.13'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+hdf5:
+- 1.14.6
+macos_machine:
+- x86_64-apple-darwin13.4.0
+mpi:
+- mpich
+mpich:
+- '4'
+numpy:
+- '2'
+openmpi:
+- '5'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.14.* *_cp314t
+target_platform:
+- osx-64

--- a/.ci_support/osx_64_mpinompipython3.14.____cp314t.yaml
+++ b/.ci_support/osx_64_mpinompipython3.14.____cp314t.yaml
@@ -1,0 +1,36 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.13'
+MACOSX_SDK_VERSION:
+- '10.13'
+c_compiler:
+- clang
+c_compiler_version:
+- '19'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '10.13'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+hdf5:
+- 1.14.6
+macos_machine:
+- x86_64-apple-darwin13.4.0
+mpi:
+- nompi
+mpich:
+- '4'
+numpy:
+- '2'
+openmpi:
+- '5'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.14.* *_cp314t
+target_platform:
+- osx-64

--- a/.ci_support/osx_64_mpiopenmpipython3.14.____cp314t.yaml
+++ b/.ci_support/osx_64_mpiopenmpipython3.14.____cp314t.yaml
@@ -1,0 +1,36 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.13'
+MACOSX_SDK_VERSION:
+- '10.13'
+c_compiler:
+- clang
+c_compiler_version:
+- '19'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '10.13'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+hdf5:
+- 1.14.6
+macos_machine:
+- x86_64-apple-darwin13.4.0
+mpi:
+- openmpi
+mpich:
+- '4'
+numpy:
+- '2'
+openmpi:
+- '5'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.14.* *_cp314t
+target_platform:
+- osx-64

--- a/.ci_support/osx_arm64_mpimpichpython3.14.____cp314t.yaml
+++ b/.ci_support/osx_arm64_mpimpichpython3.14.____cp314t.yaml
@@ -1,0 +1,36 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+MACOSX_SDK_VERSION:
+- '11.0'
+c_compiler:
+- clang
+c_compiler_version:
+- '19'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '11.0'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+hdf5:
+- 1.14.6
+macos_machine:
+- arm64-apple-darwin20.0.0
+mpi:
+- mpich
+mpich:
+- '4'
+numpy:
+- '2'
+openmpi:
+- '5'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.14.* *_cp314t
+target_platform:
+- osx-arm64

--- a/.ci_support/osx_arm64_mpinompipython3.14.____cp314t.yaml
+++ b/.ci_support/osx_arm64_mpinompipython3.14.____cp314t.yaml
@@ -1,0 +1,36 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+MACOSX_SDK_VERSION:
+- '11.0'
+c_compiler:
+- clang
+c_compiler_version:
+- '19'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '11.0'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+hdf5:
+- 1.14.6
+macos_machine:
+- arm64-apple-darwin20.0.0
+mpi:
+- nompi
+mpich:
+- '4'
+numpy:
+- '2'
+openmpi:
+- '5'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.14.* *_cp314t
+target_platform:
+- osx-arm64

--- a/.ci_support/osx_arm64_mpiopenmpipython3.14.____cp314t.yaml
+++ b/.ci_support/osx_arm64_mpiopenmpipython3.14.____cp314t.yaml
@@ -1,0 +1,36 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+MACOSX_SDK_VERSION:
+- '11.0'
+c_compiler:
+- clang
+c_compiler_version:
+- '19'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '11.0'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+hdf5:
+- 1.14.6
+macos_machine:
+- arm64-apple-darwin20.0.0
+mpi:
+- openmpi
+mpich:
+- '4'
+numpy:
+- '2'
+openmpi:
+- '5'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.14.* *_cp314t
+target_platform:
+- osx-arm64

--- a/.ci_support/win_64_python3.14.____cp314t.yaml
+++ b/.ci_support/win_64_python3.14.____cp314t.yaml
@@ -1,0 +1,26 @@
+c_compiler:
+- vs2022
+c_stdlib:
+- vs
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+hdf5:
+- 1.14.6
+mpi:
+- nompi
+mpich:
+- '4'
+numpy:
+- '2'
+openmpi:
+- '5'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.14.* *_cp314t
+target_platform:
+- win-64

--- a/README.md
+++ b/README.md
@@ -64,6 +64,13 @@ Current build status
                 </a>
               </td>
             </tr><tr>
+              <td>linux_64_mpimpichpython3.14.____cp314t</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=402&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/h5py-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_mpimpichpython3.14.____cp314t" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
               <td>linux_64_mpinompipython3.10.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=402&branchName=main">
@@ -96,6 +103,13 @@ Current build status
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=402&branchName=main">
                   <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/h5py-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_mpinompipython3.14.____cp314" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_64_mpinompipython3.14.____cp314t</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=402&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/h5py-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_mpinompipython3.14.____cp314t" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -134,6 +148,13 @@ Current build status
                 </a>
               </td>
             </tr><tr>
+              <td>linux_64_mpiopenmpipython3.14.____cp314t</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=402&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/h5py-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_mpiopenmpipython3.14.____cp314t" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
               <td>linux_aarch64_mpimpichpython3.10.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=402&branchName=main">
@@ -166,6 +187,13 @@ Current build status
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=402&branchName=main">
                   <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/h5py-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_mpimpichpython3.14.____cp314" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_aarch64_mpimpichpython3.14.____cp314t</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=402&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/h5py-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_mpimpichpython3.14.____cp314t" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -204,6 +232,13 @@ Current build status
                 </a>
               </td>
             </tr><tr>
+              <td>linux_aarch64_mpinompipython3.14.____cp314t</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=402&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/h5py-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_mpinompipython3.14.____cp314t" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
               <td>linux_aarch64_mpiopenmpipython3.10.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=402&branchName=main">
@@ -236,6 +271,13 @@ Current build status
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=402&branchName=main">
                   <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/h5py-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_mpiopenmpipython3.14.____cp314" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_aarch64_mpiopenmpipython3.14.____cp314t</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=402&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/h5py-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_mpiopenmpipython3.14.____cp314t" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -274,6 +316,13 @@ Current build status
                 </a>
               </td>
             </tr><tr>
+              <td>linux_ppc64le_mpimpichpython3.14.____cp314t</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=402&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/h5py-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_ppc64le_mpimpichpython3.14.____cp314t" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
               <td>linux_ppc64le_mpinompipython3.10.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=402&branchName=main">
@@ -306,6 +355,13 @@ Current build status
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=402&branchName=main">
                   <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/h5py-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_ppc64le_mpinompipython3.14.____cp314" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_ppc64le_mpinompipython3.14.____cp314t</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=402&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/h5py-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_ppc64le_mpinompipython3.14.____cp314t" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -344,6 +400,13 @@ Current build status
                 </a>
               </td>
             </tr><tr>
+              <td>linux_ppc64le_mpiopenmpipython3.14.____cp314t</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=402&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/h5py-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_ppc64le_mpiopenmpipython3.14.____cp314t" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
               <td>osx_64_mpimpichpython3.10.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=402&branchName=main">
@@ -376,6 +439,13 @@ Current build status
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=402&branchName=main">
                   <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/h5py-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_mpimpichpython3.14.____cp314" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_mpimpichpython3.14.____cp314t</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=402&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/h5py-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_mpimpichpython3.14.____cp314t" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -414,6 +484,13 @@ Current build status
                 </a>
               </td>
             </tr><tr>
+              <td>osx_64_mpinompipython3.14.____cp314t</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=402&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/h5py-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_mpinompipython3.14.____cp314t" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
               <td>osx_64_mpiopenmpipython3.10.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=402&branchName=main">
@@ -446,6 +523,13 @@ Current build status
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=402&branchName=main">
                   <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/h5py-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_mpiopenmpipython3.14.____cp314" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_mpiopenmpipython3.14.____cp314t</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=402&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/h5py-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_mpiopenmpipython3.14.____cp314t" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -484,6 +568,13 @@ Current build status
                 </a>
               </td>
             </tr><tr>
+              <td>osx_arm64_mpimpichpython3.14.____cp314t</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=402&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/h5py-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_mpimpichpython3.14.____cp314t" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
               <td>osx_arm64_mpinompipython3.10.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=402&branchName=main">
@@ -516,6 +607,13 @@ Current build status
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=402&branchName=main">
                   <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/h5py-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_mpinompipython3.14.____cp314" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_mpinompipython3.14.____cp314t</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=402&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/h5py-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_mpinompipython3.14.____cp314t" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -554,6 +652,13 @@ Current build status
                 </a>
               </td>
             </tr><tr>
+              <td>osx_arm64_mpiopenmpipython3.14.____cp314t</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=402&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/h5py-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_mpiopenmpipython3.14.____cp314t" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
               <td>win_64_python3.10.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=402&branchName=main">
@@ -586,6 +691,13 @@ Current build status
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=402&branchName=main">
                   <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/h5py-feedstock?branchName=main&jobName=win&configuration=win%20win_64_python3.14.____cp314" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>win_64_python3.14.____cp314t</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=402&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/h5py-feedstock?branchName=main&jobName=win&configuration=win%20win_64_python3.14.____cp314t" alt="variant">
                 </a>
               </td>
             </tr>

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -4,13 +4,10 @@
 # mpi must be defined for conda-smithy lint
 {% set mpi = mpi or 'nompi' %}
 
-{% if mpi == 'nompi' %}
 # prefer nompi builds via a build number offset
-{% set build = build + 100 %}
-{% set mpi_prefix = "nompi" %}
-{% else %}
-{% set mpi_prefix = "mpi_" + mpi %}
-{% endif %}
+{% set build = build + 100 %}  # [mpi == 'nompi']
+{% set mpi_prefix = "nompi" %}  # [mpi == 'nompi']
+{% set mpi_prefix = "mpi_" + mpi %}  # [mpi != 'nompi']
 
 package:
   name: h5py

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,6 +7,9 @@
 {% if mpi == 'nompi' %}
 # prefer nompi builds via a build number offset
 {% set build = build + 100 %}
+{% set mpi_prefix = "nompi" %}
+{% else %}
+{% set mpi_prefix = "mpi_" + mpi %}
 {% endif %}
 
 package:
@@ -24,11 +27,6 @@ source:
 build:
   skip: true  # [py<=37]
   number: {{ build }}
-  {% if mpi != 'nompi' %}
-  {% set mpi_prefix = "mpi_" + mpi %}
-  {% else %}
-  {% set mpi_prefix = "nompi" %}
-  {% endif %}
   # add build string so packages can depend on
   # mpi or nompi variants
   # dependencies:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set version = "3.15.1" %}
-{% set build = 0 %}
+{% set build = 1 %}
 
 # mpi must be defined for conda-smithy lint
 {% set mpi = mpi or 'nompi' %}

--- a/recipe/run_test.py
+++ b/recipe/run_test.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import sysconfig
 
 os.environ['OMPI_MCA_plm'] = 'isolated'
 os.environ['OMPI_MCA_btl_vader_single_copy_mechanism'] = 'none'
@@ -36,14 +37,27 @@ test_args = []
 if have_mpi:
     test_args.append("--with-mpi")
 
+# Build list of tests to skip
+skip_tests = []
+
+# Skip test_multiprocess on free-threading builds
+is_freethreaded = bool(sysconfig.get_config_var("Py_GIL_DISABLED"))
+if is_freethreaded:
+    skip_tests.append("test_multiprocess")
+
 # HDF5 1.14.4 and 1.14.5 have a regression in unicode handling on windows
 # https://github.com/conda-forge/hdf5-feedstock/issues/240
 # https://github.com/HDFGroup/hdf5/issues/5037
 # https://github.com/h5py/h5py/pull/2520
 if (
-    sys.platform == 'win32' and 
+    sys.platform == 'win32' and
     h5py.h5.get_libversion() in [(1, 14, 4), (1, 14, 5)]
 ):
-    test_args.extend(["-k", '"(not test_unicode_hdf5_python_consistent)"'])
+    skip_tests.append("test_unicode_hdf5_python_consistent")
+
+# Apply test skip filter if any tests should be skipped
+if skip_tests:
+    skip_expr = " and ".join(f"not {test}" for test in skip_tests)
+    test_args.extend(["-k", f'"{skip_expr}"'])
 
 sys.exit(h5py.run_tests(" ".join(test_args)))


### PR DESCRIPTION
Same as #161 (which itself is the same as #159 + test skip) + fix for linting errors

> For recipe/meta.yaml:

>    ℹ️ The recipe is not parsable by parser conda-recipe-manager. The recipe can only be automatically migrated to the new v1 format if it is parseable by conda-recipe-manager.

Trying to move the jinja block to top-level and use selector.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
